### PR TITLE
Powerup Model CS Compatibility Fix

### DIFF
--- a/powerup.lua
+++ b/powerup.lua
@@ -73,7 +73,29 @@ function get_character_model(m)
     }
 end
 
-hook_event(HOOK_MARIO_UPDATE, get_character_model)
+--- Charselect Model fix. By OneCalledRPG
+function cs_model_set(m)
+    if _G.charSelectExists then
+        if _G.charSelect.character_get_current_number() == 1 then
+            get_character_model(m)
+        else
+            powerupStates = {
+                [NORMAL] = { modelId = nil },
+                [TANOOKI] = { modelId = nil },
+                [CAT] = { modelId = nil },
+                [BEE] = { modelId = nil },
+                [CLOUD] = { modelId = nil },
+                [ROCKET] = { modelId = nil },
+                [BATTERY] = { modelId = nil },
+                [GRAVITY] = { modelId = nil },
+            }
+        end
+    else
+        get_character_model(m)
+    end
+end
+
+hook_event(HOOK_MARIO_UPDATE, cs_model_set)
 
 -- Powerup Model Functions --
 


### PR DESCRIPTION
Same thing as with Last Impact, code that sets the powerup model to nil if you're using a Character Select skin to preserve compatibility